### PR TITLE
统一图片/视频/摄像头推理报表模型并改为Excel主导出

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,10 +138,34 @@ def aggregate_bolt_records(records):
     return aggregated
 
 
+UNIFIED_REPORT_COLUMNS = ["图片ID", "螺栓ID", "螺栓状态", "置信度", "x1", "y1", "x2", "y2"]
+
+
+def to_unified_report_rows(records):
+    unified_rows = []
+    for record in records or []:
+        unified_rows.append(
+            {
+                "图片ID": record.get("图片ID", ""),
+                "螺栓ID": record.get("螺栓ID", record.get("bolt_id", "")),
+                "螺栓状态": record.get("螺栓状态", record.get("status", record.get("class", ""))),
+                "置信度": record.get("置信度", record.get("confidence", record.get("conf", 0.0))),
+                "x1": record.get("x1", ""),
+                "y1": record.get("y1", ""),
+                "x2": record.get("x2", ""),
+                "y2": record.get("y2", ""),
+            }
+        )
+    return unified_rows
+
+
+def to_unified_report_df(records):
+    return pd.DataFrame(to_unified_report_rows(records), columns=UNIFIED_REPORT_COLUMNS)
+
+
 def aggregated_records_to_rows(aggregated, mode="image"):
     rows = []
     for bolt_id, record in sorted(aggregated.items(), key=lambda item: bolt_id_sort_key(item[0])):
-    for bolt_id, record in sorted(aggregated.items(), key=lambda item: str(item[0])):
         if mode == "video":
             rows.append({
                 "图片ID": record.get("图片ID", ""),
@@ -1964,13 +1988,14 @@ class ImageInferencePage(FunctionPage):
                 str(r.get("bolt_id", "")),
             ),
         )
+        report_df = to_unified_report_df(rows)
+        xlsx_path = os.path.join(text_part, "bolt_detection_result.xlsx")
+        csv_path = os.path.join(text_part, "bolt_detection_result.csv")
         try:
-            cols = ["图片ID", "bolt_id", "class", "confidence", "x1", "y1", "x2", "y2", "raw_path", "det_path"]
-            pd.DataFrame(rows, columns=cols).to_csv(
-                os.path.join(text_part, "bolt_detection_result.csv"), index=False
-            )
+            report_df.to_excel(xlsx_path, index=False)
+            report_df.to_csv(csv_path, index=False)
         except Exception as e:
-            QMessageBox.warning(self, "CSV保存失败", f"检测详情保存失败: {e}")
+            QMessageBox.warning(self, "报表保存失败", f"检测详情保存失败: {e}")
         try:
             fmt = "PNG"
             orig_buf = io.BytesIO()
@@ -2179,19 +2204,16 @@ class VideoInferencePage(FunctionPage):
             refresh_scan_id(scan_layout, "v")
             scan_dir = scan_layout["scan_dir"]
 
-        # 导出CSV（所有检测数据）
+        # 导出统一报表（每个螺栓仅保留最佳结果）
             if hasattr(self.thread, "frame_records"):
-                csv_path = os.path.join(scan_layout["text_part"], "bolt_detection_result.csv")
-                video_cols = ["图片ID", "frame", "bolt_id", "status", "conf", "x1", "y1", "x2", "y2", "raw_path", "det_path"]
-                video_df = pd.DataFrame(self.thread.frame_records).reindex(columns=video_cols)
-                video_df = video_df.sort_values(by=["bolt_id", "frame"], kind="stable")
-                video_df.to_csv(csv_path, index=False)
                 xlsx_path = os.path.join(scan_layout["text_part"], "bolt_detection_result.xlsx")
-                video_cols = ["图片ID", "frame", "bolt_id", "status", "conf", "x1", "y1", "x2", "y2", "raw_path", "det_path"]
-                video_df = pd.DataFrame(self.thread.frame_records).reindex(columns=video_cols)
-                video_df.to_csv(csv_path, index=False)
+                csv_path = os.path.join(scan_layout["text_part"], "bolt_detection_result.csv")
                 try:
+                    aggregated = aggregate_bolt_records(self.thread.frame_records)
+                    video_rows = aggregated_records_to_rows(aggregated, mode="video")
+                    video_df = to_unified_report_df(video_rows).sort_values(by=["螺栓ID", "图片ID"], kind="stable")
                     video_df.to_excel(xlsx_path, index=False)
+                    video_df.to_csv(csv_path, index=False)
                 except Exception:
                     pass
 
@@ -2527,13 +2549,13 @@ class CameraPage(FunctionPage):
             image_page.archive_results(rows, sample_orig, sample_ann, annotated_infos, scan_layout)
 
             try:
-                cols = ["图片ID", "bolt_id", "class", "confidence", "x1", "y1", "x2", "y2", "raw_path", "det_path"]
-                image_df = pd.DataFrame(rows, columns=cols).sort_values(
-                    by=["图片ID", "bolt_id"], kind="stable"
-                )
+                image_df = to_unified_report_df(rows).sort_values(by=["图片ID", "螺栓ID"], kind="stable")
                 image_df.to_excel(
-                pd.DataFrame(rows, columns=cols).to_excel(
                     os.path.join(scan_layout["text_part"], "bolt_detection_result.xlsx"),
+                    index=False,
+                )
+                image_df.to_csv(
+                    os.path.join(scan_layout["text_part"], "bolt_detection_result.csv"),
                     index=False,
                 )
             except Exception:
@@ -2602,19 +2624,12 @@ class CameraPage(FunctionPage):
                             pass
 
             frame_records = getattr(thread, "frame_records", None)
-            columns = ["图片ID", "frame", "bolt_id", "status", "conf", "x1", "y1", "x2", "y2", "raw_path", "det_path"]
-            if frame_records:
-                df = pd.DataFrame(frame_records)
-            else:
-                df = pd.DataFrame(columns=columns)
-
-            df = df.reindex(columns=columns)
-            df = df.sort_values(by=["bolt_id", "frame"], kind="stable")
-
-            csv_path = os.path.join(scan_layout["text_part"], "bolt_detection_result.csv")
-            df.to_csv(csv_path, index=False)
             try:
+                aggregated = aggregate_bolt_records(frame_records or [])
+                video_rows = aggregated_records_to_rows(aggregated, mode="video")
+                df = to_unified_report_df(video_rows).sort_values(by=["螺栓ID", "图片ID"], kind="stable")
                 df.to_excel(os.path.join(scan_layout["text_part"], "bolt_detection_result.xlsx"), index=False)
+                df.to_csv(os.path.join(scan_layout["text_part"], "bolt_detection_result.csv"), index=False)
             except Exception:
                 pass
 


### PR DESCRIPTION
### Motivation
- 统一各类推理入口（图片/视频/摄像头）的导出报表格式和列顺序以便后续上游处理和用户查看；
- 避免不同模式使用混淆的英文/简化列名和把 CSV 当做主导出格式的问题；
- 报表应基于“每个螺栓仅保留最佳结果”的聚合结果生成以保证每个螺栓行唯一并代表最佳检测结果；
- 规范 `图片ID` 命名使用已有的 `IMAGE#` / `frame#` 生成逻辑，避免带扩展名或临时路径。

### Description
- 新增统一报表工具：`UNIFIED_REPORT_COLUMNS`、`to_unified_report_rows`、`to_unified_report_df`，列顺序为 `图片ID / 螺栓ID / 螺栓状态 / 置信度 / x1 / y1 / x2 / y2`，并对输入字段做兼容映射（`bolt_id`/`螺栓ID`、`status`/`class` 等）。
- 将 `ImageInferencePage.archive_results` 的导出改为以 Excel 为主导（写入 `bolt_detection_result.xlsx`），并同时写入内容一致的 `bolt_detection_result.csv`，同时使用统一中文列模型导出。`archive_results` 中的异常提示文字也做了同步调整。 
- 将 `VideoInferencePage.on_finish` 的导出改为：先对 `frame_records` 按 `bolt_id` 聚合（调用 `aggregate_bolt_records` + `aggregated_records_to_rows(..., mode="video")`），再使用统一列模型导出 `.xlsx`（并附加 `.csv`）。
- 将 `CameraPage.run_post_detection` 的图片模式和视频模式导出都切换为统一中文列模型：图片模式直接导出 `xlsx`（并生成 `csv`），视频模式基于聚合后的每螺栓最佳结果导出 `xlsx`（并生成 `csv`）。
- 修复 `aggregated_records_to_rows` 中重复 `for` 行导致的缩进错误，确保文件可编译并能正确生成聚合行。 
- 保留并复用已有的 `build_image_name` / `build_frame_name` 生成的 `图片ID`（例如 `IMAGE1` 或 `frame1`），导出不会包含扩展名或临时路径。 

### Testing
- 运行 `python -m py_compile main.py`，结果：通过，文件可编译无语法错误。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca09297d3c83208f5dbc7fd23d7721)